### PR TITLE
update default video placeholder

### DIFF
--- a/R/author_templates.R
+++ b/R/author_templates.R
@@ -51,7 +51,7 @@ test_mc(2) # if 2 is the correct option.
   
 video_body <- 
 "*** =video_link
-//player.vimeo.com/video/108225030
+//player.vimeo.com/video/154783078
 "
   
 course_yaml_template <- 

--- a/tests/testthat/test-author.R
+++ b/tests/testthat/test-author.R
@@ -98,12 +98,12 @@ test_that("add_exercise works as expected", {
   expect_equal(out$exercises[[1]]$title, "Test")
   expect_equal(out$exercises[[1]]$type, "VideoExercise")
   expect_equal(out$exercises[[1]]$lang, "r")
-  expect_equal(out$exercises[[1]]$video_link, "//player.vimeo.com/video/108225030")
+  expect_equal(out$exercises[[1]]$video_link, "//player.vimeo.com/video/154783078")
   
   expect_equal(out$exercises[[2]]$title, "Test 2")
   expect_equal(out$exercises[[2]]$type, "VideoExercise")
   expect_equal(out$exercises[[2]]$lang, "python")
-  expect_equal(out$exercises[[2]]$video_link, "//player.vimeo.com/video/108225030")
+  expect_equal(out$exercises[[2]]$video_link, "//player.vimeo.com/video/154783078")
 })
 
 test_that("build_scaffold works as expected", {


### PR DESCRIPTION
@vincentvankrunkelsven @filipsch Just changed the video link to match the newer one that we use in the teach app. This only affects the `build_scaffold()` output.